### PR TITLE
Make the lidl ocr also support regex with pattern date.month.year to capture date time

### DIFF
--- a/script.js
+++ b/script.js
@@ -332,7 +332,8 @@ export function parseLidlOcrResult(text) {
 	}
 
 	const dateRegex = /\d{4}\/\d{2}\/\d{2}/;
-	const match = text.match(dateRegex);
+	const dateMonthYearRegex = /\d{2}\.\d{2}\.\d{4}/;
+	const match = text.match(dateRegex) || text.match(dateMonthYearRegex);
 	if (!match) {
 		log('Date not found in the OCR text');
 	}
@@ -343,8 +344,13 @@ export function parseLidlOcrResult(text) {
 	});
 
 	const dateString = match[0];
-	// Note: JavaScript interprets date strings in UTC by default
-	const date = (new Date(dateString)).toLocaleDateString('sv-SE');
+	let date;
+	if (dateRegex.test(dateString)) {
+		date = (new Date(dateString)).toLocaleDateString('sv-SE');
+	} else if (dateMonthYearRegex.test(dateString)) {
+		const [day, month, year] = dateString.split('.');
+		date = new Date(`${year}-${month}-${day}`).toLocaleDateString('sv-SE');
+	}
 	return {
 		transaction_date: date, items: items
 	};


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/luqmansen/receipt-ocr-money-manager/pull/5?shareId=730b708c-7792-427c-a0f7-cee453740ca5).